### PR TITLE
Informational version supports four components

### DIFF
--- a/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/BuildIntegrationTests.cs
@@ -1050,8 +1050,14 @@ public abstract class BuildIntegrationTests : RepoTestBase, IClassFixture<MSBuil
 
         string expectedBuildMetadataWithoutCommitId = additionalBuildMetadata.Any() ? $"+{string.Join(".", additionalBuildMetadata)}" : string.Empty;
 
+        var optionalFourthComponent = versionOptions.VersionHeightPosition switch
+        {
+            SemanticVersion.Position.Revision => $".{idAsVersion.Revision}",
+            _ => ""
+        };
+
         Assert.Equal($"{version}", buildResult.AssemblyFileVersion);
-        Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}{versionOptions.Version.Prerelease}{expectedBuildMetadata}", buildResult.AssemblyInformationalVersion);
+        Assert.Equal($"{idAsVersion.Major}.{idAsVersion.Minor}.{idAsVersion.Build}{optionalFourthComponent}{versionOptions.Version.Prerelease}{expectedBuildMetadata}", buildResult.AssemblyInformationalVersion);
 
         // The assembly version property should always have four integer components to it,
         // per bug https://github.com/dotnet/Nerdbank.GitVersioning/issues/26

--- a/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
+++ b/src/NerdBank.GitVersioning.Tests/VersionOracleTests.cs
@@ -67,6 +67,30 @@ public abstract class VersionOracleTests : RepoTestBase
     }
 
     [Fact]
+    public void Informational_version_has_four_components_when_three_component_version_is_used()
+    {
+        var versionOptions = new VersionOptions { Version = SemanticVersion.Parse("1.2.3") };
+
+        this.WriteVersionFile(versionOptions);
+        this.InitializeSourceControl();
+        this.AddCommits(20);
+        var oracle = new VersionOracle(this.Context);
+        Assert.StartsWith("1.2.3.21+", oracle.AssemblyInformationalVersion);
+    }
+
+    [Fact]
+    public void Informational_version_has_three_components_when_two_component_version_is_used()
+    {
+        var versionOptions = new VersionOptions { Version = SemanticVersion.Parse("1.2") };
+
+        this.WriteVersionFile(versionOptions);
+        this.InitializeSourceControl();
+        this.AddCommits(20);
+        var oracle = new VersionOracle(this.Context);
+        Assert.StartsWith("1.2.21+", oracle.AssemblyInformationalVersion);
+    }
+
+    [Fact]
     public void MajorMinorPrereleaseBuildMetadata()
     {
         VersionOptions workingCopyVersion = new VersionOptions

--- a/src/NerdBank.GitVersioning/SemanticVersion.cs
+++ b/src/NerdBank.GitVersioning/SemanticVersion.cs
@@ -76,7 +76,7 @@
         /// <summary>
         /// Identifies the various positions in a semantic version.
         /// </summary>
-        internal enum Position
+        public enum Position
         {
             /// <summary>
             /// The <see cref="Version.Major"/> component.

--- a/src/NerdBank.GitVersioning/VersionOptions.cs
+++ b/src/NerdBank.GitVersioning/VersionOptions.cs
@@ -421,7 +421,7 @@ namespace Nerdbank.GitVersioning
         /// Gets the position in a computed version that the version height should appear.
         /// </summary>
         [JsonIgnore]
-        internal SemanticVersion.Position? VersionHeightPosition
+        public SemanticVersion.Position? VersionHeightPosition
         {
             get
             {

--- a/src/NerdBank.GitVersioning/VersionOracle.cs
+++ b/src/NerdBank.GitVersioning/VersionOracle.cs
@@ -75,6 +75,11 @@ namespace Nerdbank.GitVersioning
 
             this.VersionOptions = this.CommittedVersion ?? this.WorkingVersion;
             this.Version = this.VersionOptions?.Version?.Version ?? Version0;
+            this.VersionHeightFieldPosition = this.VersionOptions?.VersionHeightPosition switch
+            {
+                SemanticVersion.Position.Revision => 4,
+                _ => 3
+            };
 
             // Override the typedVersion with the special build number and revision components, when available.
             if (context.IsRepository)
@@ -102,6 +107,15 @@ namespace Nerdbank.GitVersioning
                     expr => Regex.IsMatch(this.BuildingRef, expr));
             }
         }
+
+        /// <summary>
+        /// The field (component) position of the version height.
+        /// </summary>
+        /// <remarks>
+        /// If the user specifies "1.2.3" as the version number, the field position is 4.
+        /// If the user specifies "1.2", then the field position is 3. For all other scenarios, it also is set to 3.
+        /// </remarks>
+        public int VersionHeightFieldPosition { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="VersionOptions"/> that were deserialized from the contextual commit, if any.
@@ -181,7 +195,7 @@ namespace Nerdbank.GitVersioning
         /// Gets the version string to use for the <see cref="System.Reflection.AssemblyInformationalVersionAttribute"/>.
         /// </summary>
         public string AssemblyInformationalVersion =>
-            $"{this.Version.ToStringSafe(3)}{this.PrereleaseVersion}{FormatBuildMetadata(this.BuildMetadataWithCommitId)}";
+            $"{this.Version.ToStringSafe(this.VersionHeightFieldPosition)}{this.PrereleaseVersion}{FormatBuildMetadata(this.BuildMetadataWithCommitId)}";
 
         /// <summary>
         /// Gets or sets a value indicating whether the project is building


### PR DESCRIPTION
If the user specifies a three-component version number in their
`version.json`, for example `"1.2.3"`, then the InformationalVersion
property will show something like `"1.2.3.50+metadata"`, where `50` is
the build height.

The previous behavior is still retained when users specify a
two-component version number, such as `"1.2"`.